### PR TITLE
[Feature/09/aop to security] AOP에서 Security로

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testRuntimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/intellipick/onboarding/auth/aop/RoleCheckAspect.java
+++ b/src/main/java/com/intellipick/onboarding/auth/aop/RoleCheckAspect.java
@@ -4,7 +4,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
+import java.lang.reflect.Method;
 
 @Aspect
 @Component
@@ -15,10 +17,17 @@ public class RoleCheckAspect {
 
     @Before("@annotation(roleCheck)")
     public void checkRole(RoleCheck roleCheck) {
+        System.out.println("[RoleCheckAspect] AOP 실행됨 - 메소드 접근 시도");
+
         String userRole = (String) request.getAttribute("role");
+        System.out.println("[RoleCheckAspect] 요청한 사용자 역할: " + userRole);
+        System.out.println("[RoleCheckAspect] 필요한 역할: " + roleCheck.value());
 
         if (userRole == null || !userRole.equals(roleCheck.value())) {
+            System.out.println("[RoleCheckAspect] 접근 거부: 권한 없음");
             throw new SecurityException("권한이 없습니다.");
         }
+
+        System.out.println("[RoleCheckAspect] 접근 허용됨");
     }
 }

--- a/src/main/java/com/intellipick/onboarding/auth/config/SecurityConfig.java
+++ b/src/main/java/com/intellipick/onboarding/auth/config/SecurityConfig.java
@@ -6,16 +6,17 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.intellipick.onboarding.auth.security.JwtFilter;
 
 @Configuration
 public class SecurityConfig {
 
-
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.disable())
             .formLogin(form -> form.disable())
             .httpBasic(httpBasic -> httpBasic.disable())
             .authorizeHttpRequests(auth -> auth
@@ -25,12 +26,15 @@ public class SecurityConfig {
                     "/swagger-resources/**",
                     "/webjars/**"
                 ).permitAll()
-                .requestMatchers("/api/**").permitAll()
+                .requestMatchers("/api/login", "/api/signup").permitAll()
+                .requestMatchers("/admin").hasAuthority("ROLE_ADMIN")
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
 
 
     @Bean

--- a/src/main/java/com/intellipick/onboarding/auth/config/SwaggerConfig.java
+++ b/src/main/java/com/intellipick/onboarding/auth/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package com.intellipick.onboarding.auth.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,17 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Intellipick API 문서")
-                        .version("1.0")
-                        .description("Intellipick 프로젝트의 API 명세서입니다."));
+            .info(new Info()
+                .title("Intellipick API")
+                .version("1.0")
+                .description("인텔리픽 API 문서"))
+            .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+            .components(new io.swagger.v3.oas.models.Components()
+                .addSecuritySchemes("BearerAuth",
+                    new SecurityScheme()
+                        .name("BearerAuth")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")));
     }
 }

--- a/src/main/java/com/intellipick/onboarding/auth/controller/AuthController.java
+++ b/src/main/java/com/intellipick/onboarding/auth/controller/AuthController.java
@@ -3,12 +3,13 @@ package com.intellipick.onboarding.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.intellipick.onboarding.auth.aop.RoleCheck;
 import com.intellipick.onboarding.auth.dto.LoginRequest;
 import com.intellipick.onboarding.auth.dto.LoginResponse;
 import com.intellipick.onboarding.auth.service.AuthService;
@@ -28,10 +29,11 @@ public class AuthController {
 		return ResponseEntity.ok(authService.login(request));
 	}
 
-	@RoleCheck("ROLE_ADMIN")
 	@GetMapping("/admin")
-	@Operation(summary = "관리자 전용 페이지", description = "관리자 권한이 있는 사용자만 접근할 수 있습니다.")
+	@Operation(summary = "관리자 접근 API", description = "관리자만 접근 가능한 페이지입니다. 관리자 ID : admin, Password : qwer1234")
 	public ResponseEntity<String> adminAccess() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		System.out.println("[AdminController] 현재 인증 정보: " + auth);
 		return ResponseEntity.ok("관리자만 접근 가능합니다! 당신은 관리자군요");
 	}
 }

--- a/src/main/resources/Application.yaml
+++ b/src/main/resources/Application.yaml
@@ -9,6 +9,9 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  logging:
+    level:
+      root: DEBUG
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/src/main/resources/Application.yaml
+++ b/src/main/resources/Application.yaml
@@ -23,5 +23,6 @@ springdoc:
     path: /swagger-ui
     operations-sorter: method
     tags-sorter: alpha
+    persist-authorization: true
   show-actuator: true
 

--- a/src/test/java/com/intellipick/onboarding/auth/security/JwtUtilTest.java
+++ b/src/test/java/com/intellipick/onboarding/auth/security/JwtUtilTest.java
@@ -4,22 +4,15 @@ import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
 class JwtUtilTest {
 
     private JwtUtil jwtUtil;
 
-    @Value("${jwt.secret}")
-    private String secretKey;
-
     @BeforeEach
     void setUp() {
-        jwtUtil = new JwtUtil(secretKey);
+        jwtUtil = new JwtUtil("templlo123456789templlo123456789templlo123456789templlo123456789templlo123456789templlo123456789");  // ✅ 직접 SecretKey 주입 (환경 변수 불필요)
     }
 
     @Test

--- a/src/test/java/com/intellipick/onboarding/auth/security/JwtUtilTest.java
+++ b/src/test/java/com/intellipick/onboarding/auth/security/JwtUtilTest.java
@@ -4,15 +4,19 @@ import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
 class JwtUtilTest {
 
+    @Autowired
     private JwtUtil jwtUtil;
 
     @BeforeEach
     void setUp() {
-        jwtUtil = new JwtUtil("templlo123456789templlo123456789templlo123456789templlo123456789templlo123456789templlo123456789");  // ✅ 직접 SecretKey 주입 (환경 변수 불필요)
+        jwtUtil.setSecretKey("templlo123456789templlo123456789templlo123456789");
     }
 
     @Test

--- a/src/test/java/com/intellipick/onboarding/auth/service/UserServiceTest.java
+++ b/src/test/java/com/intellipick/onboarding/auth/service/UserServiceTest.java
@@ -69,7 +69,8 @@ class UserServiceTest {
             .role(Role.ROLE_USER)
             .build();
 
-        when(userRepository.findByUsername(request.username())).thenReturn(Optional.of(existingUser));
+        when(userRepository.findByUsername(request.username()))
+            .thenReturn(Optional.of(existingUser));
 
         IllegalArgumentException thrownException = assertThrows(
             IllegalArgumentException.class,
@@ -79,4 +80,6 @@ class UserServiceTest {
 
         assertEquals("이미 존재하는 사용자입니다.", thrownException.getMessage());
     }
+
+
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+jwt:
+  secret: test-secret-key
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui


### PR DESCRIPTION
#️⃣ **Issue Number**
- 관련된 이슈 번호를 입력하세요: #9 

---

## 📝 **요약 (Summary)**
- Spring Security의 hasRole("ADMIN") 방식으로 접근 제어 적용
- JwtFilter에서 Spring Security Context에 GrantedAuthority 저장
- Swagger UI 접근 가능하도록 Security 설정 수정

---

## **PR 타입**
- 아래에서 해당하는 PR 유형을 선택하세요(체크박스를 `x`로 표시).
    - [ ] x

---

## 💬 **공유사항 (to 리뷰어)**
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/2a55d513-598c-4ed5-a2b6-ed49afca515c" />
- 현재는 가입하면 일반 유저로 되기 때문에 관리자 아이디, 패스워드를 적어뒀습니다. 이를 통해 로그인 후 Authorization에 입력해주면 사진처럼 잘 접속이 됩니다!

## ✅ **PR Checklist**
- [ ] x
---

